### PR TITLE
fix(windows): remove clipboard compensation logic

### DIFF
--- a/src-tauri/src/commands/selection.rs
+++ b/src-tauri/src/commands/selection.rs
@@ -8,9 +8,6 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 use tauri::AppHandle;
 
-#[cfg(target_os = "windows")]
-use crate::SELECTION_TEXT_CACHE;
-
 // maximum wait time in milliseconds for clipboard to update
 static MAX_WAIT_TIME: AtomicU64 = AtomicU64::new(1000);
 
@@ -23,12 +20,6 @@ pub async fn get_selection(app: AppHandle, mouse: Option<bool>) -> Result<String
     // try using platform native API to get selected text first
     if let Ok(text) = platform::get_selection() {
         if !text.is_empty() {
-            // clear cache to avoid stale data
-            #[cfg(target_os = "windows")]
-            if let Ok(mut cache) = SELECTION_TEXT_CACHE.lock() {
-                *cache = None;
-            }
-
             return Ok(text);
         }
     }
@@ -78,12 +69,6 @@ async fn get_selection_fallback(app: AppHandle, mouse: bool) -> Result<String, A
                 max_wait_time.as_millis()
             );
         } else {
-            // cache the selected text with current timestamp
-            #[cfg(target_os = "windows")]
-            if let Ok(mut cache) = SELECTION_TEXT_CACHE.lock() {
-                *cache = Some((selected_text.clone(), std::time::Instant::now()));
-            }
-
             // adjust max wait time for next time
             MAX_WAIT_TIME
                 .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {

--- a/src-tauri/src/handlers/mouse.rs
+++ b/src-tauri/src/handlers/mouse.rs
@@ -14,9 +14,7 @@ use std::time::{Duration, Instant};
 use tauri::{Emitter, Manager};
 
 #[cfg(target_os = "windows")]
-use crate::commands::{get_clipboard_text, set_clipboard_text};
-#[cfg(target_os = "windows")]
-use crate::{CLIPBOARD_RESTORE_INTERRUPTED, SELECTION_TEXT_CACHE};
+use crate::CLIPBOARD_RESTORE_INTERRUPTED;
 
 /// Type alias for mouse click data (time, position, is_valid_cursor).
 type Click = (Instant, (f64, f64), bool);
@@ -74,38 +72,10 @@ pub fn handle_mouse_event(event: Event) {
                 CTRL_PRESSED.set(true);
             }
 
-            // detect user Ctrl+C operation on Windows
+            // mark clipboard restore as interrupted if user presses Ctrl+C
             #[cfg(target_os = "windows")]
             if matches!(key, Key::KeyC) && CTRL_PRESSED.get() {
                 CLIPBOARD_RESTORE_INTERRUPTED.store(true, Ordering::Relaxed);
-                debug!("Ctrl+C detected, marking clipboard restore as interrupted");
-
-                let cached_text = SELECTION_TEXT_CACHE.lock().ok().and_then(|cache| {
-                    cache.as_ref().and_then(|(text, cached_at)| {
-                        if cached_at.elapsed() < Duration::from_secs(1) {
-                            Some(text.clone())
-                        } else {
-                            None
-                        }
-                    })
-                });
-                if let Some(cached_text) = cached_text {
-                    tauri::async_runtime::spawn(async move {
-                        // wait briefly for OS to finish processing the Ctrl+C copy
-                        tokio::time::sleep(Duration::from_millis(100)).await;
-                        // check if clipboard content matches cached selection
-                        if let Ok(current) = get_clipboard_text() {
-                            if current.trim() != cached_text.trim() {
-                                // clipboard was overwritten by restore before interrupt fired
-                                // compensate by writing the cached selection back
-                                debug!(
-                                    "Ctrl+C compensation: restoring cached selection to clipboard"
-                                );
-                                let _ = set_clipboard_text(cached_text);
-                            }
-                        }
-                    });
-                }
             }
 
             // hide toolbar on key press

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,7 +13,6 @@ use rdev::listen;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicU64};
 use std::sync::{LazyLock, Mutex};
-use std::time::Instant;
 use tauri::{App, AppHandle, Emitter, Manager, RunEvent, WebviewWindow, WindowEvent};
 use tauri_plugin_deep_link::DeepLinkExt;
 use tauri_plugin_log::{Target, TargetKind};
@@ -55,9 +54,6 @@ pub static CLIPBOARD: LazyLock<Mutex<Result<ClipboardContext, String>>> =
 // global clipboard interrupted state for backup-restore flow
 pub static CLIPBOARD_RESTORE_INTERRUPTED: AtomicBool = AtomicBool::new(false);
 
-// global selected text cache with timestamp
-pub static SELECTION_TEXT_CACHE: LazyLock<Mutex<Option<(String, Instant)>>> =
-    LazyLock::new(|| Mutex::new(None));
 
 #[cfg(target_os = "macos")]
 use tauri_nspanel::{


### PR DESCRIPTION
## Problem

On Windows, a `Ctrl+C` conflict occurred when the toolbar popup appeared: pressing `Ctrl+C` immediately after a text selection would sometimes fail to copy the selected text.

A previous workaround was introduced using a `SELECTION_TEXT_CACHE` — a time-bounded in-memory cache of the selected text. When `Ctrl+C` was detected, it would compare the clipboard contents against the cache and overwrite the clipboard if they differed. This was brittle and introduced side effects.

## Root Cause

The actual cause is that `show_toolbar_regardless()` calls `window.show()`, which triggers `SW_SHOW` under the hood. `SW_SHOW` activates the window and **steals keyboard focus** from the user's original application.

When the user presses `Ctrl+C` quickly (within ~50ms of the toolbar appearing), the `C` key fires while TextGO still holds focus — so the copy goes nowhere. After ~1 second (once the user has switched focus back), `Ctrl+C` works correctly. This timing-dependent behavior is consistent with a focus-stealing race, not a clipboard data problem.

The correct fix is to use `SW_SHOWNOACTIVATE` so the toolbar never steals focus.

## Changes

Remove the now-unnecessary compensation logic:

- `lib.rs`: remove `SELECTION_TEXT_CACHE` global (`LazyLock<Mutex<Option<(String, Instant)>>>`) and `use std::time::Instant`
- `selection.rs`: remove `SELECTION_TEXT_CACHE` import, cache-clear on native path, and cache-write on clipboard fallback path
- `handlers/mouse.rs`: remove async compensation block in `Ctrl+C` handler; retain only `CLIPBOARD_RESTORE_INTERRUPTED.store(true)` (still needed for the backup-restore cycle in `clipboard.rs`)

## Testing

Built and installed on Windows x64 (v0.9.7). Verified:
- Text selection and toolbar display work normally
- `CLIPBOARD_RESTORE_INTERRUPTED` flag still correctly guards the backup-restore flow in `clipboard.rs`
- No regression in clipboard behavior