### PR TITLE
fix(windows): toolbar focus + Ctrl+C race + disabled-trigger sync

### DIFF
--- a/src-tauri/src/commands/clipboard.rs
+++ b/src-tauri/src/commands/clipboard.rs
@@ -41,12 +41,17 @@ where
     F: FnOnce() -> Fut,
     Fut: std::future::Future<Output = Result<T, AppError>>,
 {
-    // reset interrupted state before operation
-    CLIPBOARD_RESTORE_INTERRUPTED.store(false, Ordering::Relaxed);
-
-    // backup all format contents
+    // backup all format contents FIRST so that any user Ctrl+C that landed
+    // just before this task started is captured into the backup itself.
     let contents = run(|| Ok(CLIPBOARD.lock()?.as_ref()?.get(&ALL_FORMATS)?))?;
     debug!("Clipboard backup: saved original clipboard contents");
+
+    // reset interrupted state ONLY AFTER backup. Resetting before backup
+    // would erase the user's pre-task Ctrl+C signal, and the subsequent
+    // restore would overwrite the user's intentional copy on apps where
+    // UIAutomation returns empty and we fall back to the polling clipboard
+    // method (e.g. WeChat).
+    CLIPBOARD_RESTORE_INTERRUPTED.store(false, Ordering::Relaxed);
 
     // execute operation
     let result = operation().await?;

--- a/src-tauri/src/commands/selection.rs
+++ b/src-tauri/src/commands/selection.rs
@@ -8,9 +8,6 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 use tauri::AppHandle;
 
-#[cfg(target_os = "windows")]
-use crate::SELECTION_TEXT_CACHE;
-
 // maximum wait time in milliseconds for clipboard to update
 static MAX_WAIT_TIME: AtomicU64 = AtomicU64::new(1000);
 
@@ -23,12 +20,6 @@ pub async fn get_selection(app: AppHandle, mouse: Option<bool>) -> Result<String
     // try using platform native API to get selected text first
     if let Ok(text) = platform::get_selection() {
         if !text.is_empty() {
-            // clear cache to avoid stale data
-            #[cfg(target_os = "windows")]
-            if let Ok(mut cache) = SELECTION_TEXT_CACHE.lock() {
-                *cache = None;
-            }
-
             return Ok(text);
         }
     }
@@ -78,12 +69,6 @@ async fn get_selection_fallback(app: AppHandle, mouse: bool) -> Result<String, A
                 max_wait_time.as_millis()
             );
         } else {
-            // cache the selected text with current timestamp
-            #[cfg(target_os = "windows")]
-            if let Ok(mut cache) = SELECTION_TEXT_CACHE.lock() {
-                *cache = Some((selected_text.clone(), std::time::Instant::now()));
-            }
-
             // adjust max wait time for next time
             MAX_WAIT_TIME
                 .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {

--- a/src-tauri/src/commands/shortcut.rs
+++ b/src-tauri/src/commands/shortcut.rs
@@ -1,7 +1,7 @@
 use crate::error::AppError;
 use crate::{
-    IBEAM_CURSOR, LONG_PRESS, LONG_PRESS_DURATION, REGISTERED_SHORTCUTS, SHORTCUT_PAUSED,
-    SHORTCUT_SUSPEND,
+    IBEAM_CURSOR, LONG_PRESS, LONG_PRESS_DURATION, MOUSE_DBCLICK_TRIGGER, MOUSE_DRAG_TRIGGER,
+    MOUSE_SHIFT_TRIGGER, REGISTERED_SHORTCUTS, SHORTCUT_PAUSED, SHORTCUT_SUSPEND,
 };
 use std::sync::atomic::Ordering;
 use tauri::AppHandle;
@@ -160,6 +160,27 @@ pub fn set_long_press_duration(duration: u64) -> Result<(), AppError> {
 #[tauri::command]
 pub fn set_ibeam_cursor_enabled(enabled: bool) -> Result<(), AppError> {
     IBEAM_CURSOR.store(enabled, Ordering::Relaxed);
+    Ok(())
+}
+
+/// Set mouse drag trigger enabled state.
+#[tauri::command]
+pub fn set_mouse_drag_trigger(enabled: bool) -> Result<(), AppError> {
+    MOUSE_DRAG_TRIGGER.store(enabled, Ordering::Relaxed);
+    Ok(())
+}
+
+/// Set mouse double-click trigger enabled state.
+#[tauri::command]
+pub fn set_mouse_dbclick_trigger(enabled: bool) -> Result<(), AppError> {
+    MOUSE_DBCLICK_TRIGGER.store(enabled, Ordering::Relaxed);
+    Ok(())
+}
+
+/// Set shift+click trigger enabled state.
+#[tauri::command]
+pub fn set_mouse_shift_trigger(enabled: bool) -> Result<(), AppError> {
+    MOUSE_SHIFT_TRIGGER.store(enabled, Ordering::Relaxed);
     Ok(())
 }
 

--- a/src-tauri/src/handlers/mouse.rs
+++ b/src-tauri/src/handlers/mouse.rs
@@ -40,6 +40,27 @@ const MAX_DBCLICK_INTERVAL: Duration = Duration::from_millis(500);
 
 /// Handle mouse event.
 pub fn handle_mouse_event(event: Event) {
+    // Track Ctrl/Ctrl+C state regardless of suspend/pause so the user's Ctrl+C
+    // can interrupt our clipboard backup-restore cycle. Without this, while
+    // get_selection is running (SHORTCUT_SUSPEND=true), the user's Ctrl+C is
+    // silently overwritten by our restore step, making copy fail for the
+    // ~1s window that the clipboard fallback is polling.
+    #[cfg(target_os = "windows")]
+    {
+        match &event.event_type {
+            EventType::KeyPress(Key::ControlLeft | Key::ControlRight) => {
+                CTRL_PRESSED.set(true);
+            }
+            EventType::KeyRelease(Key::ControlLeft | Key::ControlRight) => {
+                CTRL_PRESSED.set(false);
+            }
+            EventType::KeyPress(Key::KeyC) if CTRL_PRESSED.get() => {
+                CLIPBOARD_RESTORE_INTERRUPTED.store(true, Ordering::Relaxed);
+            }
+            _ => {}
+        }
+    }
+
     // check if shortcut handling is suspended or paused
     if SHORTCUT_SUSPEND.load(Ordering::Relaxed) || SHORTCUT_PAUSED.load(Ordering::Relaxed) {
         return;

--- a/src-tauri/src/handlers/mouse.rs
+++ b/src-tauri/src/handlers/mouse.rs
@@ -14,9 +14,7 @@ use std::time::{Duration, Instant};
 use tauri::{Emitter, Manager};
 
 #[cfg(target_os = "windows")]
-use crate::commands::{get_clipboard_text, set_clipboard_text};
-#[cfg(target_os = "windows")]
-use crate::{CLIPBOARD_RESTORE_INTERRUPTED, SELECTION_TEXT_CACHE};
+use crate::CLIPBOARD_RESTORE_INTERRUPTED;
 
 /// Type alias for mouse click data (time, position, is_valid_cursor).
 type Click = (Instant, (f64, f64), bool);
@@ -74,38 +72,10 @@ pub fn handle_mouse_event(event: Event) {
                 CTRL_PRESSED.set(true);
             }
 
-            // detect user Ctrl+C operation on Windows
+            // mark clipboard restore as interrupted if user presses Ctrl+C
             #[cfg(target_os = "windows")]
             if matches!(key, Key::KeyC) && CTRL_PRESSED.get() {
                 CLIPBOARD_RESTORE_INTERRUPTED.store(true, Ordering::Relaxed);
-                debug!("Ctrl+C detected, marking clipboard restore as interrupted");
-
-                let cached_text = SELECTION_TEXT_CACHE.lock().ok().and_then(|cache| {
-                    cache.as_ref().and_then(|(text, cached_at)| {
-                        if cached_at.elapsed() < Duration::from_secs(1) {
-                            Some(text.clone())
-                        } else {
-                            None
-                        }
-                    })
-                });
-                if let Some(cached_text) = cached_text {
-                    tauri::async_runtime::spawn(async move {
-                        // wait briefly for OS to finish processing the Ctrl+C copy
-                        tokio::time::sleep(Duration::from_millis(100)).await;
-                        // check if clipboard content matches cached selection
-                        if let Ok(current) = get_clipboard_text() {
-                            if current.trim() != cached_text.trim() {
-                                // clipboard was overwritten by restore before interrupt fired
-                                // compensate by writing the cached selection back
-                                debug!(
-                                    "Ctrl+C compensation: restoring cached selection to clipboard"
-                                );
-                                let _ = set_clipboard_text(cached_text);
-                            }
-                        }
-                    });
-                }
             }
 
             // hide toolbar on key press

--- a/src-tauri/src/handlers/mouse.rs
+++ b/src-tauri/src/handlers/mouse.rs
@@ -2,8 +2,8 @@ use crate::commands::{get_selection, is_blocked};
 use crate::error::AppError;
 use crate::platform;
 use crate::{
-    APP_HANDLE, ENIGO, IBEAM_CURSOR, LONG_PRESS, LONG_PRESS_DURATION, SHORTCUT_PAUSED,
-    SHORTCUT_SUSPEND,
+    APP_HANDLE, ENIGO, IBEAM_CURSOR, LONG_PRESS, LONG_PRESS_DURATION, MOUSE_DBCLICK_TRIGGER,
+    MOUSE_DRAG_TRIGGER, MOUSE_SHIFT_TRIGGER, SHORTCUT_PAUSED, SHORTCUT_SUSPEND,
 };
 use enigo::Mouse;
 use log::debug;
@@ -170,7 +170,7 @@ fn handle_mouse_release() -> Result<(), AppError> {
     // check for drag end
     if IS_DRAGGING.get() {
         debug!("Checking for drag end (cursor: {})", is_valid_cursor);
-        if is_valid_cursor {
+        if is_valid_cursor && MOUSE_DRAG_TRIGGER.load(Ordering::Relaxed) {
             // emit drag end event
             emit_event("MouseClick+MouseMove", None)?;
         }
@@ -181,7 +181,7 @@ fn handle_mouse_release() -> Result<(), AppError> {
     // check for shift+click
     if SHIFT_PRESSED.get() {
         debug!("Checking for shift+click (cursor: {})", is_valid_cursor);
-        if is_valid_cursor {
+        if is_valid_cursor && MOUSE_SHIFT_TRIGGER.load(Ordering::Relaxed) {
             // emit shift+click event
             emit_event("Shift+MouseClick", None)?;
         }
@@ -204,7 +204,7 @@ fn handle_mouse_release() -> Result<(), AppError> {
             "Checking for double click (cursor: {}, interval: {}, distance: {})",
             valid_cursor, valid_interval, valid_distance
         );
-        if valid_cursor && valid_interval && valid_distance {
+        if valid_cursor && valid_interval && valid_distance && MOUSE_DBCLICK_TRIGGER.load(Ordering::Relaxed) {
             // emit double click event
             emit_event("MouseClick+MouseClick", None)?;
             // reset last click state

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -54,6 +54,11 @@ pub static CLIPBOARD: LazyLock<Mutex<Result<ClipboardContext, String>>> =
 // global clipboard interrupted state for backup-restore flow
 pub static CLIPBOARD_RESTORE_INTERRUPTED: AtomicBool = AtomicBool::new(false);
 
+// global mouse trigger enabled states (disabled by default, enabled by frontend when rules exist)
+pub static MOUSE_DRAG_TRIGGER: AtomicBool = AtomicBool::new(false);
+pub static MOUSE_DBCLICK_TRIGGER: AtomicBool = AtomicBool::new(false);
+pub static MOUSE_SHIFT_TRIGGER: AtomicBool = AtomicBool::new(false);
+
 
 #[cfg(target_os = "macos")]
 use tauri_nspanel::{
@@ -167,6 +172,9 @@ pub fn run() {
             set_long_press_duration,
             set_ibeam_cursor_enabled,
             get_selection,
+            set_mouse_drag_trigger,
+            set_mouse_dbclick_trigger,
+            set_mouse_shift_trigger,
             get_clipboard_text,
             set_clipboard_text,
             clear_clipboard,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -301,6 +301,27 @@ fn setup_app(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {
                 width: 1.0,
                 height: 1.0,
             }));
+
+            // on Windows, mark toolbar as non-activating so window.show() does not
+            // steal keyboard focus from the foreground app. This is a one-time
+            // window-style change applied at creation; it does NOT touch the show
+            // pipeline and therefore avoids the SW_SHOWNOACTIVATE flash-and-vanish
+            // regression documented in skills/textgo-build/references/troubleshooting.md
+            #[cfg(target_os = "windows")]
+            {
+                use windows::Win32::Foundation::HWND;
+                use windows::Win32::UI::WindowsAndMessaging::{
+                    GetWindowLongPtrW, SetWindowLongPtrW, GWL_EXSTYLE, WS_EX_NOACTIVATE,
+                };
+                if let Ok(raw) = window.hwnd() {
+                    let hwnd = HWND(raw.0);
+                    unsafe {
+                        let cur = GetWindowLongPtrW(hwnd, GWL_EXSTYLE);
+                        let new = cur | WS_EX_NOACTIVATE.0 as isize;
+                        SetWindowLongPtrW(hwnd, GWL_EXSTYLE, new);
+                    }
+                }
+            }
         }),
     );
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,7 +13,6 @@ use rdev::listen;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicU64};
 use std::sync::{LazyLock, Mutex};
-use std::time::Instant;
 use tauri::{App, AppHandle, Emitter, Manager, RunEvent, WebviewWindow, WindowEvent};
 use tauri_plugin_deep_link::DeepLinkExt;
 use tauri_plugin_log::{Target, TargetKind};
@@ -55,9 +54,6 @@ pub static CLIPBOARD: LazyLock<Mutex<Result<ClipboardContext, String>>> =
 // global clipboard interrupted state for backup-restore flow
 pub static CLIPBOARD_RESTORE_INTERRUPTED: AtomicBool = AtomicBool::new(false);
 
-// global selected text cache with timestamp
-pub static SELECTION_TEXT_CACHE: LazyLock<Mutex<Option<(String, Instant)>>> =
-    LazyLock::new(|| Mutex::new(None));
 
 #[cfg(target_os = "macos")]
 use tauri_nspanel::{

--- a/src/lib/shortcut.ts
+++ b/src/lib/shortcut.ts
@@ -5,8 +5,16 @@ import type { Rule } from '$lib/types';
 import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
 import { getCurrentWindow } from '@tauri-apps/api/window';
-import { LONG_PRESS_SHORTCUT } from './constants';
+import { DBCLICK_SHORTCUT, DRAG_SHORTCUT, LONG_PRESS_SHORTCUT, SHIFT_CLICK_SHORTCUT } from './constants';
 import { isMouseShortcut } from './helpers';
+
+/** Map mouse shortcut string to the backend command that enables/disables it. */
+function getMouseTriggerCommand(shortcut: string): string | null {
+  if (shortcut === DRAG_SHORTCUT) return 'set_mouse_drag_trigger';
+  if (shortcut === DBCLICK_SHORTCUT) return 'set_mouse_dbclick_trigger';
+  if (shortcut === SHIFT_CLICK_SHORTCUT) return 'set_mouse_shift_trigger';
+  return null;
+}
 
 /**
  * Update case ID in rules with given prefix.
@@ -147,6 +155,11 @@ export class Manager {
       // save rule to frontend registry
       const s = shortcuts.current[shortcut];
       if (s && s.rules && !s.rules.find((r) => r.id === rule.id)) {
+        // notify backend when the first rule is added for a mouse shortcut
+        if (isMouseShortcut(shortcut) && s.rules.length === 0) {
+          const cmd = getMouseTriggerCommand(shortcut);
+          if (cmd) await invoke(cmd, { enabled: true });
+        }
         s.rules.push(rule);
       }
     } catch (error) {
@@ -170,8 +183,11 @@ export class Manager {
         if (index !== -1) {
           s.rules.splice(index, 1);
         }
-        // unregister backend shortcut when no remaining rules
-        if (!isMouseShortcut(shortcut) && s.rules.length === 0) {
+        // notify backend when no remaining rules
+        if (isMouseShortcut(shortcut) && s.rules.length === 0) {
+          const cmd = getMouseTriggerCommand(shortcut);
+          if (cmd) await invoke(cmd, { enabled: false });
+        } else if (!isMouseShortcut(shortcut) && s.rules.length === 0) {
           await invoke('unregister_shortcut', { shortcut });
         }
       }

--- a/src/lib/shortcut.ts
+++ b/src/lib/shortcut.ts
@@ -17,6 +17,23 @@ function getMouseTriggerCommand(shortcut: string): string | null {
 }
 
 /**
+ * Push the current effective state of a mouse shortcut to the backend.
+ * Effective = has at least one rule AND not disabled.
+ * Safe to call for any shortcut; non-mouse shortcuts are ignored.
+ */
+export async function syncMouseTrigger(shortcut: string): Promise<void> {
+  const cmd = getMouseTriggerCommand(shortcut);
+  if (!cmd) return;
+  const s = shortcuts.current[shortcut];
+  const enabled = !!s && !s.disabled && Array.isArray(s.rules) && s.rules.length > 0;
+  try {
+    await invoke(cmd, { enabled });
+  } catch (error) {
+    console.error(`Failed to sync mouse trigger for ${shortcut}: ${error}`);
+  }
+}
+
+/**
  * Update case ID in rules with given prefix.
  *
  * @param prefix - case ID prefix
@@ -155,12 +172,9 @@ export class Manager {
       // save rule to frontend registry
       const s = shortcuts.current[shortcut];
       if (s && s.rules && !s.rules.find((r) => r.id === rule.id)) {
-        // notify backend when the first rule is added for a mouse shortcut
-        if (isMouseShortcut(shortcut) && s.rules.length === 0) {
-          const cmd = getMouseTriggerCommand(shortcut);
-          if (cmd) await invoke(cmd, { enabled: true });
-        }
         s.rules.push(rule);
+        // sync backend mouse trigger flag (no-op for keyboard shortcuts)
+        await syncMouseTrigger(shortcut);
       }
     } catch (error) {
       console.error(`Failed to register rule: ${error}`);
@@ -183,11 +197,10 @@ export class Manager {
         if (index !== -1) {
           s.rules.splice(index, 1);
         }
-        // notify backend when no remaining rules
-        if (isMouseShortcut(shortcut) && s.rules.length === 0) {
-          const cmd = getMouseTriggerCommand(shortcut);
-          if (cmd) await invoke(cmd, { enabled: false });
-        } else if (!isMouseShortcut(shortcut) && s.rules.length === 0) {
+        // sync backend mouse trigger flag (no-op for keyboard shortcuts)
+        await syncMouseTrigger(shortcut);
+        // unregister keyboard shortcut at backend when last rule removed
+        if (!isMouseShortcut(shortcut) && s.rules.length === 0) {
           await invoke('unregister_shortcut', { shortcut });
         }
       }

--- a/src/routes/(main)/shortcuts/+page.svelte
+++ b/src/routes/(main)/shortcuts/+page.svelte
@@ -2,6 +2,7 @@
   import { alert, Binder, Button, BWList, confirm, Icon, List, Recorder, Shortcut, Toggle } from '$lib/components';
   import { DBCLICK_SHORTCUT, DRAG_SHORTCUT, SHIFT_CLICK_SHORTCUT } from '$lib/constants';
   import { formatShortcut, isMouseShortcut } from '$lib/helpers';
+  import { syncMouseTrigger } from '$lib/shortcut';
   import { NoData } from '$lib/icons';
   import { m } from '$lib/paraglide/messages';
   import { blacklist, longPress, shortcuts } from '$lib/stores.svelte';
@@ -263,8 +264,11 @@
           class="ml-auto {disabled ? 'text-emphasis' : 'text-inactive'}"
           iconClass={disabled ? '' : 'rotate-90'}
           text={disabled ? m.enable_shortcut() : m.disable_shortcut()}
-          onclick={() => {
+          onclick={async () => {
             shortcuts.current[shortcut].disabled = !shortcuts.current[shortcut].disabled;
+            // sync backend mouse trigger flag so disabled mouse shortcuts no longer
+            // trigger get_selection / focus stealing in the source app
+            await syncMouseTrigger(shortcut);
           }}
         />
         <Button


### PR DESCRIPTION
## Summary

A bundle of Windows-only fixes for the toolbar focus, the keyboard-shortcut/clipboard race conditions, and the disabled-trigger sync. This PR replaces #42 (now closed) — its commit (`5116182`) is included here so the upstream review surface is a single PR instead of two stacked ones.

## Bugs fixed

### 1. `Ctrl+C` after drag-select copies fails (the "toolbar steals focus" bug)
**Cause**: `show_toolbar_regardless` calls `window.show()`, which on Windows uses `SW_SHOW` and activates the toolbar. The toolbar steals keyboard focus from the source app, so an immediate `Ctrl+C` is delivered to TextGO instead of the source.

**Fix** (`f874f9f`): Apply `WS_EX_NOACTIVATE` extended window style to the toolbar HWND once at creation. The toolbar appears but never activates; the source app keeps focus and the user's `Ctrl+C` is delivered correctly.

We deliberately do **not** use `SW_SHOWNOACTIVATE` on the show call. Bypassing Tauri/Wry's show pipeline causes the toolbar/popup to flash for one frame and self-hide because Tauri reconciles its visibility state. `WS_EX_NOACTIVATE` solves the same problem at the window-style layer without fighting the show pipeline.

### 2. `Ctrl+C` during the 1s clipboard fallback gets silently overwritten
**Cause**: While `get_selection`'s clipboard fallback polls (up to 1s on Windows when UIAutomation returns empty), the early-return at the top of `handle_mouse_event` short-circuits `Ctrl+C` interrupt detection. `CLIPBOARD_RESTORE_INTERRUPTED` never gets set during this window, and `with_clipboard_backup` runs its restore at the end and silently overwrites the user's intentional `Ctrl+C` copy.

**Fix** (`0d54a9d`): Move `Ctrl`/`Ctrl+C` tracking to run **before** the suspend/pause guard. The interrupt flag is now set even during the suspend window.

### 3. WeChat-style apps: fast `Ctrl+C` after drag still loses the copy
**Cause**: `with_clipboard_backup` reset the interrupt flag *before* taking the backup. If the user's `Ctrl+C` arrived just before the spawned `get_selection` task started, the reset wiped the signal, and if the keystroke had not yet landed in the source app at the time of backup, the restore at the end overwrites the user's copy that lands later.

**Fix** (`3f0bda1`): Move the flag reset to *after* the backup is taken. The backup either captures the user's already-landed copy (so a later restore is a no-op), or the keystroke arrives during the operation and the in-task setter wins (so the end-of-task swap returns true and restore is skipped). Either way the user's copy survives. Browsers/Word/VS Code use the UIA fast path and never enter this code.

### 4. Disabled mouse trigger still steals focus
**Cause**: The per-shortcut backend flags `MOUSE_DRAG_TRIGGER` / `MOUSE_DBCLICK_TRIGGER` / `MOUSE_SHIFT_TRIGGER` were updated only on rule register/unregister — not when the user toggled the per-shortcut "disable" switch. A user who disabled a mouse trigger via the toggle still saw Word's Mini Toolbar flash and disappear because the backend kept calling `get_selection`/UIAutomation.

**Fix** (`3184203`): Add a `syncMouseTrigger(shortcut)` helper that recomputes the effective state (`rules.length > 0 && !disabled`) and pushes it to the backend; called from `Manager.register`, `Manager.unregister`, and the disable-toggle handler. Companion: `c02639a` introduces the backend gating that this helper drives.

### 5. Removal of the brittle clipboard compensation logic (`5116182`)
The previous compensation logic in the `Ctrl+C` handler kept a time-bounded `SELECTION_TEXT_CACHE` and rewrote the clipboard if a Ctrl+C race overwrote it. With the four fixes above it is no longer needed and is removed.

## Commits

- `5116182` fix(windows): remove clipboard compensation logic
- `c02639a` fix(mouse): skip selection fetch when mouse triggers are disabled
- `f874f9f` fix(windows): apply WS_EX_NOACTIVATE to toolbar window
- `0d54a9d` fix(windows): detect user Ctrl+C even while shortcut handling is suspended
- `3184203` fix(mouse): sync mouse-trigger backend flags with disabled toggle
- `3f0bda1` fix(windows): defer interrupt-flag reset until after clipboard backup

## Tested on

- Windows 11 x64 native build (NSIS installer)
- Drag-select → immediate Ctrl+C copies correctly in Word, Chrome, VS Code, **WeChat**
- Drag-select with all mouse triggers disabled → Word Mini Toolbar stays visible
- 1-second clipboard-fallback window no longer eats Ctrl+C
- Toolbar/popup still appears and stays (no flash-and-vanish regression)